### PR TITLE
Fix include guard in gamerzilla.h

### DIFF
--- a/gamerzilla.h
+++ b/gamerzilla.h
@@ -1,4 +1,4 @@
-#ifndef __gammerzilla_h__
+#ifndef __gamerzilla_h__
 #define __gamerzilla_h__
 
 #include <stdbool.h>


### PR DESCRIPTION
Fix a GCC warning:

```
/usr/include/gamerzilla/gamerzilla.h:1: warning: header guard ‘__gammerzilla_h__’ followed by ‘#define’ of a different macro [-Wheader-guard]
    1 | #ifndef __gammerzilla_h__
/usr/include/gamerzilla/gamerzilla.h:2: note: ‘__gamerzilla_h__’ is defined here; did you mean ‘__gammerzilla_h__’?
    2 | #define __gamerzilla_h__
```